### PR TITLE
Update python version due to workflow failures

### DIFF
--- a/.github/workflows/data-pull-13.yml
+++ b/.github/workflows/data-pull-13.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   update-data:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
       - name: checkout repo content


### PR DESCRIPTION
The latest ubuntu version is causing issues with setting up python in the workflow, according to this issues thread: [https://github.com/actions/setup-python/issues/162], reverting back to Ubuntu 20.04 should address this problem until the latest version is fixed.